### PR TITLE
Proposed bug fix when enabling S3 bucket server access logging

### DIFF
--- a/Infrastructure/modules/S3/main.tf
+++ b/Infrastructure/modules/S3/main.tf
@@ -89,7 +89,17 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "s3_bucket_encrypt
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "log_owner" {
+  count  = local.create_logging_bucket
+  bucket = aws_s3_bucket.logging_bucket[0].id
+  rule {
+    object_ownership = var.object_ownership
+  }
+}
+
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.log_owner]
+
   count  = local.create_logging_bucket
   bucket = aws_s3_bucket.logging_bucket[0].id
   acl    = "log-delivery-write"


### PR DESCRIPTION
- include log bucket ownership control resource
- make log bucket acl dependent on ownership control