### PR TITLE
Updated the Lambda module with a fix, as it was giving issues related…

### DIFF
--- a/Infrastructure/modules/Lambda/main.tf
+++ b/Infrastructure/modules/Lambda/main.tf
@@ -26,8 +26,8 @@ resource "aws_iam_role" "iam_for_lambda" {
 
 
 resource "aws_iam_role_policy_attachment" "lambda_policy" {
-  for_each   = var.policy_arns
-  policy_arn = each.value
+  count      = length(var.policy_arns)
+  policy_arn = var.policy_arns[count.index]
   role       = aws_iam_role.iam_for_lambda.name
   depends_on = [aws_iam_role.iam_for_lambda]
 }

--- a/Infrastructure/modules/Lambda/variables.tf
+++ b/Infrastructure/modules/Lambda/variables.tf
@@ -303,7 +303,7 @@ variable "is_lambda_layer" {
 
 variable "policy_arns" {
   description = "Specify the policy arns to be attached to the lambda role"
-  type        = set(string)
+  type        = list(string)
   default     = []
 }
 


### PR DESCRIPTION
… to supplying the role with policy attachement arns

The issue below was showing up when the actions of plan and apply would occur. I have tried several differenct alternatives to try and get it working but continously hit a dead end with this error and also viewed the error slack. [https://stackoverflow.com/questions/63768921/the-for-each-value-depends-on-resource-attributes-that-cannot-be-determined-t](url)

So the changes revert back to count as that is fully functional.

```
│ Error: Invalid for_each argument
│
│   on ..\..\..\..\Modules\.terraform\modules\main\Infrastructure\modules\Lambda\main.tf line 29, in resource "aws_iam_role_policy_attachment" "lambda_policy":
│   29:   for_each   = var.policy_arns
│     ├────────────────
│     │ var.policy_arns is set of string with 6 elements
│
│ The "for_each" set includes values derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this  
│ resource.
│
│ When working with unknown values in for_each, it's better to use a map value where the keys are defined statically in your configuration and where only the values contain apply-time results.
│
│ Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
```



